### PR TITLE
Replace argument typehint by interface

### DIFF
--- a/src/Services/CacheKeyService.php
+++ b/src/Services/CacheKeyService.php
@@ -3,14 +3,14 @@
 namespace RVanGinneken\AssetBundle\Services;
 
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class CacheKeyService
 {
     private $requestStack;
     private $tokenStorage;
 
-    public function __construct(RequestStack $requestStack, TokenStorage $tokenStorage)
+    public function __construct(RequestStack $requestStack, TokenStorageInterface $tokenStorage)
     {
         $this->requestStack = $requestStack;
         $this->tokenStorage = $tokenStorage;


### PR DESCRIPTION
The service `CacheKeyService` uses `TokenStorage` as type hint for the second parameter. With this PR, the typehint is replaced by `TokenStorageInterface` which is needed for the next Symfony LTS version